### PR TITLE
DataFrames.sort is deprecated, replaced by sort_values

### DIFF
--- a/src/fitter/fitter.py
+++ b/src/fitter/fitter.py
@@ -283,7 +283,7 @@ class Fitter(object):
 
         """
         # self.df should be sorted, so then us take the first one as the best
-        name = self.df_errors.sort('sumsquare_error').iloc[0].name
+        name = self.df_errors.sort_values('sumsquare_error').iloc[0].name
         params = self.fitted_param[name]
         return {name: params}
 


### PR DESCRIPTION
The DataFrames object no longer has an attribute sort, so use sort_values instead to make it work again

see i.e. https://stackoverflow.com/a/44123892/5586297

scipy 0.19.1
pandas 0.19.2