### PR TITLE
Use is_alive in favour of isAlive for Python 3.9 compatibility.

### DIFF
--- a/src/fitter/fitter.py
+++ b/src/fitter/fitter.py
@@ -423,7 +423,7 @@ class Fitter(object):
             a, b, c = it.exc_info
             raise Exception(a, b, c)  # communicate that to caller
 
-        if it.isAlive():  # pragma: no cover
+        if it.is_alive():  # pragma: no cover
             it.suicide()
             raise RuntimeError
         else:


### PR DESCRIPTION
Fixes #31 