### PR TITLE
Update timeout in docs from 10 to 30 seconds

### DIFF
--- a/src/fitter/fitter.py
+++ b/src/fitter/fitter.py
@@ -113,7 +113,7 @@ class Fitter(object):
     :attr:`distributions` with a subset if you want. In order to reload all distributions,
     call :meth:`load_all_distributions`.
 
-    Some distributions do not converge when fitting. There is a timeout of 10 seconds after which
+    Some distributions do not converge when fitting. There is a timeout of 30 seconds after which
     the fitting procedure is cancelled. You can change this :attr:`timeout` attribute if needed.
 
     If the histogram of the data has outlier of very long tails, you may want to increase the


### PR DESCRIPTION
@cokelaer FYI [rOpenSci](https://ropensci.org) is developing [standards for Statistical Software](https://stats-devguide.ropensci.org), and in the process of developing standards for probability distributions software. `fitter` is a really good benchmark for a number of aspects, including user-friendliness, ease of fitting and comparing multiple distributions, and the excellent parallel implementations of multiple fit procedures - the `_timed_run` function is great! Thanks for the great work!