### PR TITLE
Make tests not leave temporary files

### DIFF
--- a/test/test_main.py
+++ b/test/test_main.py
@@ -1,32 +1,39 @@
+import pytest
+from pathlib import Path
 from easydev import TempFile
 import subprocess
+from scipy import stats
 from fitter.main import fitdist
 
-# generate dummy data 
-from scipy import stats
-data1 = stats.gamma.rvs(2, loc=1.5, scale=2, size=10000)
-data2 = stats.gamma.rvs(1, loc=1.5, scale=3, size=10000)
-tt = open("test.csv", "w")
-for x, y in zip(data1, data2):
-    tt.write("{},{}\n".format(x,y))
+@pytest.fixture
+def setup_teardown():
+    # generate dummy data
+    data1 = stats.gamma.rvs(2, loc=1.5, scale=2, size=10000)
+    data2 = stats.gamma.rvs(1, loc=1.5, scale=3, size=10000)
+    with open("test.csv", "w") as tmp:
+        for x, y in zip(data1, data2):
+            tmp.write("{},{}\n".format(x,y))
+
+    # hand over control to test
+    yield
+
+    # remove files left by testing
+    filenames = ['test.csv', 'fitter.log', 'fitter.png']
+    for filename in filenames:
+        file = Path(filename)
+        if file.exists():
+            file.unlink()
 
 
-
-def test_main_app():
+def test_main_app(setup_teardown):
     from click.testing import CliRunner
     runner = CliRunner()
 
     results = runner.invoke(fitdist, ['--help'])
     assert results.exit_code == 0
-    with TempFile() as fin:
-        tt = open(fin.name, "w")
-        for x, y in zip(data1, data2):
-            tt.write("{},{}\n".format(x,y))
-        results = runner.invoke(fitdist, [fin.name, "--no-verbose"])
-        assert results.exit_code == 0
-        results = runner.invoke(fitdist, [fin.name, "--progress", "--column-number", 1])
-        assert results.exit_code == 0
-        # here, fitter.log and fitter.png have been created. FIXME should remove
-        # them properly
 
+    results = runner.invoke(fitdist, ['test.csv', "--no-verbose"])
+    assert results.exit_code == 0
 
+    results = runner.invoke(fitdist, ['test.csv', "--progress", "--column-number", 1])
+    assert results.exit_code == 0


### PR DESCRIPTION
This is achieved by using pytest fixture for tempfiles relating to tests. That way, the tempfiles are set up and torn down properly.