### PR TITLE
Make the setup.py license match the repository license (GPL3).

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ metainfo = {
           'Development Status :: 5 - Production/Stable',
           'Intended Audience :: Developers',
           'Intended Audience :: Science/Research',
-          'License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)',
+          'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
           'Operating System :: OS Independent',
           'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: 3.4',


### PR DESCRIPTION
Currently there's conflicting licensing information; `LICENSE` (and hence Github) says GPL-3.0, while the `setup.py` licensing classifier says LGPL. I assume GPL-3.0 is what is meant instead.