### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     maintainer_email = metainfo['authors']['Cokelaer'][1],
     author           = metainfo['authors']['Cokelaer'][0],
     author_email     = metainfo['authors']['Cokelaer'][1],
-    long_description = open("README.rst").read(),
+    long_description = open("README.rst", encoding='utf-8').read(),
     keywords         = metainfo['keywords'],
     description = metainfo['description'],
     license          = metainfo['license'],
@@ -51,7 +51,7 @@ setup(
     # package installation
     package_dir = {'':'src'},
     packages = ['fitter'],
-    install_requires = open("requirements.txt").read(),
+    install_requires = open("requirements.txt", encoding='utf-8').read(),
     entry_points = {
         'console_scripts':[
            'fitter=fitter.main:main', 


### PR DESCRIPTION
Add encoding='utf-8', because in windows system, the default coding of `open` is not always utf8, for example, GBK encoding for chinese users. So when I `pip install fitter`, I got
```
Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "C:\Users\xxx\AppData\Local\Temp\pip-install-hfyxp3sg\fitter_62b800038c7b4ad78d2f3bf992e0c8f3\setup.py", line 41, in <module>
          long_description = open("README.rst").read(),
      UnicodeDecodeError: 'gbk' codec can't decode byte 0xa6 in position 4339: illegal multibyte sequence
```
add encoding='utf-8' will fix this.