### PR TITLE
 Introducing 'get_params' Functionality

### DIFF
--- a/src/fitter/fitter.py
+++ b/src/fitter/fitter.py
@@ -442,7 +442,6 @@ class Fitter(object):
             param_names = (distribution.shapes + ", loc, scale").split(", ") if distribution.shapes else ["loc", "scale"]
             param_dict = {}
             for d_key, d_val in zip(param_names, params):param_dict[d_key] = d_val
-            print(f"name: {name}, params: {param_dict}")
             return {name: param_dict}
         except:raise Exception("%s was not fitted. no parameters available" % name)
 

--- a/src/fitter/fitter.py
+++ b/src/fitter/fitter.py
@@ -435,6 +435,31 @@ class Fitter(object):
             param_dict[d_key] = d_val
         return {name: param_dict}
 
+    def _get_params(self, name):
+        try:
+            params = self.fitted_param[name]
+            distribution = getattr(scipy.stats, name)
+            param_names = (distribution.shapes + ", loc, scale").split(", ") if distribution.shapes else ["loc", "scale"]
+            param_dict = {}
+            for d_key, d_val in zip(param_names, params):param_dict[d_key] = d_val
+            print(f"name: {name}, params: {param_dict}")
+            return {name: param_dict}
+        except:raise Exception("%s was not fitted. no parameters available" % name)
+
+    def get_params(self, names):
+        """Return list of selected result distributions.
+
+        :param str,list names: names can be single distribution name or a list
+        of distribution names.
+
+        """
+        params = {}
+        if isinstance(names, list):
+            for name in names:
+                params.update(self._get_params(name))
+            return params
+        else: return {_get_params(names)}
+
     def summary(self, Nbest=5, lw=2, plot=True, method="sumsquare_error", clf=True):
         """Plots the distribution of the data and N best distributions"""
         if plot:


### PR DESCRIPTION
## What?
This commit introduces a new functionality named 'get_params' to the Fitter module. The 'get_params' function retrieves single or multiple parameters and organizes them within a dictionary. To ensure its functionality and exception handling, thorough testing has been performed. Below are the results of the tests conducted.

## Why?
The inspiration behind this addition stemmed from my recent use of Fitter for distribution analysis. While comparing basic distributions with the best distribution suggested by Fitter, I found the need to plot these distributions for comparison. However, to plot them using scipy, I required the parameters of the distributions. Recognizing the usefulness of this feature, some of my university classmates also expressed interest in it. Therefore, I took the initiative to implement it in Fitter and contribute to this module.

## Tests
```py
import pandas as pd
from fitter import Fitter


if __name__ == "__main__":
    df = pd.read_csv("https://raw.githubusercontent.com/plotly/datasets/master/tesla-stock-price.csv")
    df["returns"] = df["close"].pct_change().dropna()
    df = df.dropna()
    print(df.head(5))

    # fit Fitter
    f = Fitter(df["returns"], distributions=["dweibull", "norm", "gamma"])
    f.fit()

    # Fitter summary
    f.summary()
    print(f.get_best())

    # get params that exist
    print("Params that exists")
    print(f.get_params(["norm", "gamma"]))

    # get params that don't exist
    print("\n\nParams that don't exists")
    print(f.get_params(["norm", "purplee"])) # purple does not exists
```

## Results
With correct fitted models results.
```
{'dweibull': {'c': 1.0447062923363082, 'loc': 0.00013648228620834018, 'scale': 0.01995679546976726}}
Params that exists
{'norm': {'loc': 0.00011569720457830373, 'scale': 0.027617014894550405}, 'gamma': {'a': 466.8393465126668, 'loc': -0.5996304202684424, 'scale': 0.0012844002683708561}}
```

With incorrect fitted models results.
```
Params that don't exists
Traceback (most recent call last):
  File "/Users/h3cth0r/Documents/fitter-add/fitter/src/fitter/fitter.py", line 440, in _get_params
    params = self.fitted_param[name]
KeyError: 'purplee'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/h3cth0r/Documents/fitter-add/tests/test_get_params.py", line 25, in <module>
    print(f.get_params(["norm", "purplee"]))
  File "/Users/h3cth0r/Documents/fitter-add/fitter/src/fitter/fitter.py", line 458, in get_params
    params.update(self._get_params(name))
  File "/Users/h3cth0r/Documents/fitter-add/fitter/src/fitter/fitter.py", line 446, in _get_params
    except:raise Exception("%s was not fitted. no parameters available" % name)
Exception: purplee was not fitted. no parameters available
```