### PR TITLE
[Fix]  Modify the logging behavior accroding to the loguru documentat…

### DIFF
--- a/src/fitter/__init__.py
+++ b/src/fitter/__init__.py
@@ -1,5 +1,5 @@
 from importlib import metadata
-
+from loguru import logger
 
 def get_package_version(package_name):
     try:
@@ -14,3 +14,6 @@ version = get_package_version("fitter")
 
 from .fitter import Fitter, get_common_distributions, get_distributions
 from .histfit import HistFit
+
+# Disable default logging.
+logger.disable('fitter')


### PR DESCRIPTION
The loguru document said as follows:

> By default, a third-library should not emit logs except if specifically requested. For this reason, there exist the disable() and enable() methods. Make sure to first call logger.disable("mylib"). This avoids library logs to be mixed with those of the user. The user can always call logger.enable("mylib") if he wants to access the logs of your library.